### PR TITLE
New classifications

### DIFF
--- a/client/src/Store.ts
+++ b/client/src/Store.ts
@@ -1,5 +1,5 @@
 import { observable, action } from "mobx";
-import { Connection, IStateResponse } from "./Connnection";
+import { Connection } from "./Connnection";
 import { IonicAgent } from "./models/IonicAgent";
 import { DoctorModel } from "./models/DoctorModel";
 import { PatientModel } from "./models/PatientModel";
@@ -13,11 +13,11 @@ export class Store {
     connection = new Connection();
 
     patient = new IonicAgent({
-        username: "virgil_patient",
+        username: "test_patient",
         password: "password123",
         fetchIonicAssertion: () =>
             this.connection.registerUser({
-                email: "test_patient@virgilsecurity.com",
+                email: "test_patient@healthcaredemo.com",
                 groupName: "patients",
                 firstName: "Test",
                 lastName: "Patient"
@@ -25,11 +25,11 @@ export class Store {
     });
 
     doctor = new IonicAgent({
-        username: "virgil_doctor",
+        username: "test_doctor",
         password: "password123",
         fetchIonicAssertion: () =>
             this.connection.registerUser({
-                email: "test_physician@virgilsecurity.com",
+                email: "test_physician@healthcaredemo.com",
                 groupName: "physicians",
                 firstName: "Test",
                 lastName: "Physician"
@@ -37,11 +37,11 @@ export class Store {
     });
 
     insurer = new IonicAgent({
-        username: "virgil_insurer",
+        username: "test_insurer",
         password: "password123",
         fetchIonicAssertion: () =>
             this.connection.registerUser({
-                email: "test_insurer@virgilsecurity.com",
+                email: "test_insurer@healthcaredemo.com",
                 groupName: "insurers",
                 firstName: "Test",
                 lastName: "Insurer"

--- a/client/src/models/DoctorModel.ts
+++ b/client/src/models/DoctorModel.ts
@@ -9,7 +9,7 @@ export class DoctorModel {
     });
     officeNotes = new EditableColumnModel({
         sdk: this.store.doctor,
-        encryptFor:  "patient_physician",
+        classification:  "Office Visit Notes",
         onSubmit: this.store.sendVisitNotes,
         valueReaction: () => this.store.state.office_visit_notes,
         activateReaction: () => this.medicalHistory.state === "Ready"
@@ -17,7 +17,7 @@ export class DoctorModel {
 
     prescription = new EditableColumnModel({
         sdk: this.store.doctor,
-        encryptFor: "patient_physician_insurer",
+        classification: "Prescription Order",
         onSubmit: this.store.sendPrescription,
         valueReaction: () => this.store.state.prescription,
         activateReaction: () => this.medicalHistory.state === "Ready"

--- a/client/src/models/EditableColumnModel.ts
+++ b/client/src/models/EditableColumnModel.ts
@@ -1,9 +1,9 @@
 import { observable, action, reaction } from "mobx";
-import { IonicAgent } from "./IonicAgent";
+import { IonicAgent, DataClassification } from "./IonicAgent";
 
 export interface IEditableColumnModelOptions {
     sdk: IonicAgent;
-    encryptFor: string;
+    classification: DataClassification;
     onSubmit: (message: string) => Promise<string>;
     valueReaction: () => string | undefined;
     activateReaction?: () => any;
@@ -22,15 +22,15 @@ export class EditableColumnModel {
     @observable state: EditableColumnStates = "Waiting";
 
     private sdk: IonicAgent;
-    private encryptFor: string;
+    private classification: DataClassification;
     private onSubmit: (message: string) => Promise<string>;
 
 
     constructor(options: IEditableColumnModelOptions) {
-        const { sdk, encryptFor, onSubmit, valueReaction, activateReaction } = options;
+        const { sdk, classification, onSubmit, valueReaction, activateReaction } = options;
         this.sdk = sdk;
         this.onSubmit = onSubmit;
-        this.encryptFor = encryptFor;
+        this.classification = classification;
         reaction(valueReaction, data => this.activate(data));
         if (activateReaction) reaction(activateReaction, this.startEditing);
     }
@@ -52,7 +52,7 @@ export class EditableColumnModel {
     encrypt(message: string) {
         this.state = "Encrypting";
         return this.sdk
-            .encryptText(message, this.encryptFor)
+            .encryptText(message, this.classification)
             .then(encryptedMessage => {
                 this.state = "Sending";
                 return encryptedMessage;

--- a/client/src/models/InsurerModel.ts
+++ b/client/src/models/InsurerModel.ts
@@ -18,10 +18,10 @@ export class InsurerModel {
 
     insurerReply = new EditableColumnModel({
         sdk: this.store.insurer,
-        encryptFor: "patient_physician_insurer",
+        classification: "Insurance Reply",
         onSubmit: this.store.sendInsurerReply,
         valueReaction: () => this.store.state.insurer_reply,
-        activateReaction: () => this.prescription.state === "Ready"
+        activateReaction: () => this.officeNotes.state === "Ready"
     });
 
     constructor(readonly store: Store) {}

--- a/client/src/models/IonicAgent.ts
+++ b/client/src/models/IonicAgent.ts
@@ -6,7 +6,7 @@ export interface IonicAgentParams {
     fetchIonicAssertion: () => Promise<object>;
 }
 
-export type DataClassification = 'patient_physician'|'patient_physician_insurer';
+export type DataClassification = 'Medical History'|'Office Visit Notes'|'Prescription Order'|'Insurance Reply';
 
 const ActiveProfileMutex = new Mutex();
 

--- a/client/src/models/PatientModel.ts
+++ b/client/src/models/PatientModel.ts
@@ -5,7 +5,7 @@ import { ReadonlyColumnModel } from "./ReadonlyColumnModel";
 export class PatientModel {
     medicalHistory = new EditableColumnModel({
         sdk: this.store.patient,
-        encryptFor:  "patient_physician",
+        classification:  "Medical History",
         onSubmit: this.store.sendMedicalHistory,
         valueReaction: () => this.store.state.medical_history,
         activateReaction: () => this.store.state

--- a/server/ionic/data-policy.js
+++ b/server/ionic/data-policy.js
@@ -43,7 +43,8 @@ const Attributes = {
         classification: { category: 'resource', id: 'classification' }
     },
     subject: {
-        group: { category: 'subject', id: 'group' }
+        group: { category: 'subject', id: 'group' },
+        groupName: { category: 'subject', id: 'group-name' }
     }
 };
 

--- a/setup/app-data.js
+++ b/setup/app-data.js
@@ -1,0 +1,52 @@
+const MEDICAL_HISTORY = 'Medical History';
+const OFFICE_VISIT_NOTES = 'Office Visit Notes';
+const PRESCRIPTION_ORDER = 'Prescription Order';
+const INSURANCE_REPLY = 'Insurance Reply';
+
+const PATIENTS = 'Patients';
+const PHYSICIANS = 'Physicians';
+const INSURERS = 'Insurers';
+
+module.exports = {
+    APP_CLASSIFICATION_VALUES: [
+        MEDICAL_HISTORY,
+        OFFICE_VISIT_NOTES,
+        PRESCRIPTION_ORDER,
+        INSURANCE_REPLY
+    ],
+
+    APP_GROUP_NAMES: [PATIENTS, PHYSICIANS, INSURERS],
+
+    APP_POLICIES: [
+        {
+            policyId: 'Healthcare Demo Patients',
+            description: 'User is in the group Patients',
+            ruleCombiningAlgId: 'deny-overrides',
+            appliesToGroup: PATIENTS,
+            allowDataMarkedWith: [MEDICAL_HISTORY, OFFICE_VISIT_NOTES, PRESCRIPTION_ORDER, INSURANCE_REPLY],
+            get ruleDescription() {
+                return `Allow access if data is marked with classification matching ${this.allowDataMarkedWith.join(', ')}`;
+            }
+        },
+        {
+            policyId: 'Healthcare Demo Physicians',
+            description: 'User is in the group Physicians',
+            ruleCombiningAlgId: 'deny-overrides',
+            appliesToGroup: PHYSICIANS,
+            allowDataMarkedWith: [MEDICAL_HISTORY, OFFICE_VISIT_NOTES, PRESCRIPTION_ORDER, INSURANCE_REPLY],
+            get ruleDescription() {
+                return `Allow access if data is marked with classification matching ${this.allowDataMarkedWith.join(', ')}`;
+            }
+        },
+        {
+            policyId: 'Healthcare Demo Insurers',
+            description: 'User is in the group Insurers',
+            ruleCombiningAlgId: 'deny-overrides',
+            appliesToGroup: INSURERS,
+            allowDataMarkedWith: [OFFICE_VISIT_NOTES, INSURANCE_REPLY],
+            get ruleDescription() {
+                return `Allow access if data is marked with classification matching ${this.allowDataMarkedWith.join(', ')}`;
+            }
+        }
+    ]
+}

--- a/setup/create-ionic-data-markings.js
+++ b/setup/create-ionic-data-markings.js
@@ -1,5 +1,5 @@
 const { formatNamesList, reportError } = require('./utils');
-const APP_CLASSIFICATION_VALUES = ['patient_physician', 'patient_physician_insurer'];
+const { APP_CLASSIFICATION_VALUES } = require('./app-data');
 
 async function createIonicDataMarkings(client) {
     // find "classification" pre-defined data marking

--- a/setup/create-ionic-data-policies.js
+++ b/setup/create-ionic-data-policies.js
@@ -5,34 +5,17 @@ const {
     stringAtLeastOneMemberOf
 } = require('../server/ionic/data-policy');
 
-const POLICIES = [
-    {
-        policyId: 'Healthcare Demo Patient Info',
-        description: 'Data is marked with classification patient_physician',
-        ruleCombiningAlgId: 'deny-overrides',
-        classificationValues: ['patient_physician'],
-        allowedGroups: ['5cab158ce5a7320cf0fd0416', '5cab15eb3053363b20fd03c5'],
-        ruleDescription: 'Allow access if user is in the groups Patients or Physicians'
-    },
-    {
-        policyId: 'Healthcare Demo Insurance Info',
-        description: 'Data is marked with classification patient_physician_insurer',
-        ruleCombiningAlgId: 'deny-overrides',
-        classificationValues: ['patient_physician_insurer'],
-        allowedGroups: ['5cab158ce5a7320cf0fd0416', '5cab15eb3053363b20fd03c5', '5cab160c9c97e32f42fd0412'],
-        ruleDescription: 'Allow access if user is in the groups Patients, Physicians or Insurers'
-    }
-];
+const { APP_POLICIES } = require('./app-data');
 
 async function createIonicDataPolicies(client) {
     const { Resources: existingPolicies } = await client.findDataPolicies({
         searchParams: {
-            policyId: { __any: POLICIES.map(p => p.policyId) }
+            policyId: { __any: APP_POLICIES.map(p => p.policyId) }
         }
     })
 
     const existingPolicyIds = existingPolicies.map(p => p.policyId);
-    const missingPolicies = POLICIES.filter(p => existingPolicyIds.includes(p.policyId) === false);
+    const missingPolicies = APP_POLICIES.filter(p => existingPolicyIds.includes(p.policyId) === false);
 
     if (existingPolicies.length > 0) {
         console.log(`${formatNamesList(existingPolicies.map(p => p.policyId), 'Policy', 'Policies')} already exist`);
@@ -47,8 +30,8 @@ async function createIonicDataPolicies(client) {
                 ruleCombiningAlgId: p.ruleCombiningAlgId,
                 enabled: true
             })
-            .when(stringAtLeastOneMemberOf(Attributes.resource.classification, p.classificationValues))
-            .allowIf(stringAtLeastOneMemberOf(Attributes.subject.group, p.allowedGroups), p.ruleDescription)
+            .when(stringAtLeastOneMemberOf(Attributes.subject.groupName, p.appliesToGroup))
+            .allowIf(stringAtLeastOneMemberOf(Attributes.resource.classification, p.allowDataMarkedWith), p.ruleDescription)
             .toJSON();
         });
         await Promise.all(policyRequests.map(pr => client.createPolicy(pr)));

--- a/setup/create-ionic-groups.js
+++ b/setup/create-ionic-groups.js
@@ -1,5 +1,5 @@
 const { formatNamesList, reportError } = require('./utils');
-const APP_GROUP_NAMES = ['Patients', 'Physicians', 'Insurers'];
+const { APP_GROUP_NAMES } = require('./app-data');
 
 async function createIonicGroups(client) {
     const existingGroupsResponse = await client.findGroups({

--- a/setup/utils.js
+++ b/setup/utils.js
@@ -4,7 +4,7 @@ function formatNamesList(names, nameSingular, namePlural) {
     }
 
     if (names.length === 1) {
-        return `${nameSingular} ${names.toString()}`;
+        return `${nameSingular} "${names.toString()}"`;
     }
 
     if (names.length === 2) {


### PR DESCRIPTION
Now using `'Medical History'|'Office Visit Notes'|'Prescription Order'|'Insurance Reply'` as data classification values.

Also, the policy's applicability is now decided based on user's Group rather than the data classification value, i.e. we previously had policies like this:
```
Applies to: Data marked with classification matching X
Allow access when user is in the group Y
```
now the policies are like this:
```
Applies to: User is in the group Y
Allow access when data is marked with classification matching X
```
and we have 3 policies instead of 2.

Also, renamed test user's emails and names